### PR TITLE
Replace deprecated @hashgraph/sdk with @hiero-ledger/sdk

### DIFF
--- a/nodes/Hedera/core/HederaClient.ts
+++ b/nodes/Hedera/core/HederaClient.ts
@@ -1,4 +1,4 @@
-import { Client, PrivateKey } from '@hashgraph/sdk';
+import { Client, PrivateKey } from '@hiero-ledger/sdk';
 import { IHederaCredentials } from './types';
 
 export class HederaClientFactory {

--- a/nodes/Hedera/core/types.ts
+++ b/nodes/Hedera/core/types.ts
@@ -1,5 +1,5 @@
 import { IDataObject, INodeProperties } from 'n8n-workflow';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 
 export interface IHederaCredentials {
 	accountId: string;

--- a/nodes/Hedera/services/account/AccountService.ts
+++ b/nodes/Hedera/services/account/AccountService.ts
@@ -1,4 +1,4 @@
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { IDataObject, INodeProperties } from 'n8n-workflow';
 import { IHederaService, IOperationResult } from '../../core/types';
 import { CreateAccountOperation } from './CreateAccountOperation';

--- a/nodes/Hedera/services/account/CreateAccountOperation.ts
+++ b/nodes/Hedera/services/account/CreateAccountOperation.ts
@@ -1,4 +1,4 @@
-import { AccountCreateTransaction, PrivateKey, Hbar, Client } from '@hashgraph/sdk';
+import { AccountCreateTransaction, PrivateKey, Hbar, Client } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/consensus/ConsensusService.ts
+++ b/nodes/Hedera/services/consensus/ConsensusService.ts
@@ -1,4 +1,4 @@
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { IDataObject, INodeProperties } from 'n8n-workflow';
 import { IHederaService, IOperationResult } from '../../core/types';
 import { CreateTopicOperation } from './CreateTopicOperation';

--- a/nodes/Hedera/services/consensus/CreateTopicOperation.ts
+++ b/nodes/Hedera/services/consensus/CreateTopicOperation.ts
@@ -5,7 +5,7 @@ import {
 	TransactionReceipt,
 	TransactionRecord,
 	PublicKey,
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/consensus/SubmitMessageOperation.ts
+++ b/nodes/Hedera/services/consensus/SubmitMessageOperation.ts
@@ -4,7 +4,7 @@ import {
 	TransactionResponse,
 	TransactionReceipt,
 	TransactionRecord,
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/mirror/AccountBalanceQuery.ts
+++ b/nodes/Hedera/services/mirror/AccountBalanceQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client, Hbar, HbarUnit } from '@hashgraph/sdk';
+import { Client, Hbar, HbarUnit } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class AccountBalanceQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/AccountInfoQuery.ts
+++ b/nodes/Hedera/services/mirror/AccountInfoQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class AccountInfoQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/AccountNFTsQuery.ts
+++ b/nodes/Hedera/services/mirror/AccountNFTsQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class AccountNFTsQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/AccountTokensQuery.ts
+++ b/nodes/Hedera/services/mirror/AccountTokensQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class AccountTokensQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/MirrorService.ts
+++ b/nodes/Hedera/services/mirror/MirrorService.ts
@@ -1,4 +1,4 @@
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { IDataObject, INodeProperties } from 'n8n-workflow';
 import { IHederaService, IOperationResult } from '../../core/types';
 import { AccountInfoQueryOperation } from './AccountInfoQuery';

--- a/nodes/Hedera/services/mirror/TokenBalanceQuery.ts
+++ b/nodes/Hedera/services/mirror/TokenBalanceQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class TokenBalanceQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/TokenInfoQuery.ts
+++ b/nodes/Hedera/services/mirror/TokenInfoQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class TokenInfoQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/TopicMessagesQuery.ts
+++ b/nodes/Hedera/services/mirror/TopicMessagesQuery.ts
@@ -1,6 +1,6 @@
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { getMirrorConfigFromClient } from './utils';
 
 export class TopicMessagesQueryOperation implements IBaseOperation {

--- a/nodes/Hedera/services/mirror/utils.ts
+++ b/nodes/Hedera/services/mirror/utils.ts
@@ -1,5 +1,5 @@
 import createClient from 'openapi-fetch';
-import { Client, LedgerId } from '@hashgraph/sdk';
+import { Client, LedgerId } from '@hiero-ledger/sdk';
 import type { paths } from '../../core/hedera-mirror';
 
 export const getMirrorConfigFromClient = (client?: Client) => {

--- a/nodes/Hedera/services/token/AirdropFungibleTokenOperation.ts
+++ b/nodes/Hedera/services/token/AirdropFungibleTokenOperation.ts
@@ -1,4 +1,4 @@
-import { TokenAirdropTransaction, Client } from '@hashgraph/sdk';
+import { TokenAirdropTransaction, Client } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 import { TokenInfoQueryOperation } from '../mirror/TokenInfoQuery';

--- a/nodes/Hedera/services/token/AirdropNFTOperation.ts
+++ b/nodes/Hedera/services/token/AirdropNFTOperation.ts
@@ -1,4 +1,4 @@
-import { Client, TokenId, NftId, AccountId, TokenAirdropTransaction } from '@hashgraph/sdk';
+import { Client, TokenId, NftId, AccountId, TokenAirdropTransaction } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/token/CreateFungibleTokenOperation.ts
+++ b/nodes/Hedera/services/token/CreateFungibleTokenOperation.ts
@@ -1,4 +1,4 @@
-import { TokenCreateTransaction, Client, PublicKey } from '@hashgraph/sdk';
+import { TokenCreateTransaction, Client, PublicKey } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/token/CreateNFTOperation.ts
+++ b/nodes/Hedera/services/token/CreateNFTOperation.ts
@@ -4,7 +4,7 @@ import {
 	TokenSupplyType,
 	Client,
 	PublicKey,
-} from '@hashgraph/sdk';
+} from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/token/MintFungibleTokenOperation.ts
+++ b/nodes/Hedera/services/token/MintFungibleTokenOperation.ts
@@ -1,4 +1,4 @@
-import { Client, TokenId, TokenMintTransaction } from '@hashgraph/sdk';
+import { Client, TokenId, TokenMintTransaction } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 import { TokenInfoQueryOperation } from '../mirror/TokenInfoQuery';

--- a/nodes/Hedera/services/token/MintNFTOperation.ts
+++ b/nodes/Hedera/services/token/MintNFTOperation.ts
@@ -1,4 +1,4 @@
-import { TokenMintTransaction, Client, TokenId } from '@hashgraph/sdk';
+import { TokenMintTransaction, Client, TokenId } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/nodes/Hedera/services/token/TokenService.ts
+++ b/nodes/Hedera/services/token/TokenService.ts
@@ -1,4 +1,4 @@
-import { Client } from '@hashgraph/sdk';
+import { Client } from '@hiero-ledger/sdk';
 import { IDataObject, INodeProperties } from 'n8n-workflow';
 import { IHederaService, IOperationResult } from '../../core/types';
 import { AirdropFungibleTokenOperation } from './AirdropFungibleTokenOperation';

--- a/nodes/Hedera/services/token/TransferHBAROperation.ts
+++ b/nodes/Hedera/services/token/TransferHBAROperation.ts
@@ -1,4 +1,4 @@
-import { TransferTransaction, Hbar, Client } from '@hashgraph/sdk';
+import { TransferTransaction, Hbar, Client } from '@hiero-ledger/sdk';
 import { IDataObject } from 'n8n-workflow';
 import { IBaseOperation, IOperationResult } from '../../core/types';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "n8n-nodes-hedera",
-	"version": "0.3.2",
+	"version": "1.0.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "n8n-nodes-hedera",
-			"version": "0.3.2",
+			"version": "1.0.3",
 			"license": "MIT",
 			"dependencies": {
-				"@hashgraph/sdk": "^2.64.5",
+				"@hiero-ledger/sdk": "^2.85.0",
 				"openapi-fetch": "^0.14.0"
 			},
 			"devDependencies": {
@@ -28,27 +28,19 @@
 				"n8n-workflow": "*"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
+		"node_modules/@adraffy/ens-normalize": {
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+			"integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -57,9 +49,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -67,22 +59,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.6",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.0",
-				"@babel/types": "^7.28.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -108,14 +100,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-			"integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.28.0",
-				"@babel/types": "^7.28.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -125,14 +117,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -152,9 +144,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -162,29 +154,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -193,20 +185,10 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -214,18 +196,18 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -233,27 +215,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
-			"integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.2"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-			"integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.28.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -262,217 +244,10 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-syntax-async-generators": {
-			"version": "7.8.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-bigint": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-class-properties": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.12.13"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-class-static-block": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-meta": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-json-strings": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-numeric-separator": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.10.4"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-optional-chaining": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-top-level-await": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
-			"integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -480,53 +255,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-			"integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.0",
-				"debug": "^4.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/traverse--for-generate-function-map": {
-			"name": "@babel/traverse",
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-			"integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -534,14 +289,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-			"integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -647,411 +402,6 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@ethersproject/abi": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
-			"integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/address": "^5.8.0",
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/constants": "^5.8.0",
-				"@ethersproject/hash": "^5.8.0",
-				"@ethersproject/keccak256": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"@ethersproject/strings": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/abstract-provider": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
-			"integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/networks": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"@ethersproject/transactions": "^5.8.0",
-				"@ethersproject/web": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/abstract-signer": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
-			"integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/abstract-provider": "^5.8.0",
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/address": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
-			"integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/keccak256": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/rlp": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/base64": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
-			"integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/bignumber": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
-			"integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"bn.js": "^5.2.1"
-			}
-		},
-		"node_modules/@ethersproject/bytes": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
-			"integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/logger": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/constants": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
-			"integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bignumber": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/hash": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
-			"integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/abstract-signer": "^5.8.0",
-				"@ethersproject/address": "^5.8.0",
-				"@ethersproject/base64": "^5.8.0",
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/keccak256": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"@ethersproject/strings": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/keccak256": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
-			"integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0",
-				"js-sha3": "0.8.0"
-			}
-		},
-		"node_modules/@ethersproject/logger": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
-			"integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/@ethersproject/networks": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
-			"integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/logger": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/properties": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
-			"integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/logger": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/rlp": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
-			"integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/signing-key": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
-			"integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"bn.js": "^5.2.1",
-				"elliptic": "6.6.1",
-				"hash.js": "1.1.7"
-			}
-		},
-		"node_modules/@ethersproject/strings": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
-			"integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/constants": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/transactions": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
-			"integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/address": "^5.8.0",
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/constants": "^5.8.0",
-				"@ethersproject/keccak256": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"@ethersproject/rlp": "^5.8.0",
-				"@ethersproject/signing-key": "^5.8.0"
-			}
-		},
-		"node_modules/@ethersproject/web": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
-			"integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-				},
-				{
-					"type": "individual",
-					"url": "https://www.buymeacoffee.com/ricmoo"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"@ethersproject/base64": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/logger": "^5.8.0",
-				"@ethersproject/properties": "^5.8.0",
-				"@ethersproject/strings": "^5.8.0"
-			}
-		},
-		"node_modules/@grpc/grpc-js": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
-			"integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@grpc/proto-loader": "^0.7.13",
-				"@js-sdsl/ordered-map": "^4.4.2"
-			},
-			"engines": {
-				"node": ">=12.10.0"
-			}
-		},
 		"node_modules/@grpc/proto-loader": {
 			"version": "0.7.15",
 			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
@@ -1093,24 +443,28 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/@hashgraph/cryptography": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.9.0.tgz",
-			"integrity": "sha512-0UItolO1W/f8YIsGBrIxvjY+cSdvs4sEdzXOL49ThYEfPskJUprG3vhMhosRFoA4d0hxdJ7/glB7f7He8RW9xg==",
+		"node_modules/@hiero-ledger/cryptography": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@hiero-ledger/cryptography/-/cryptography-1.19.0.tgz",
+			"integrity": "sha512-6CN34QzPGpegFpQGw1dI77N+75ICdLPSSpcBQ35tyKiNruh6KjE9L0R0th5kcn5sdFw8CwHOPwDQ4+HaSyW0Yw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@noble/curves": "^1.8.1",
-				"asn1js": "^3.0.6",
-				"bignumber.js": "^9.1.1",
-				"bn.js": "^5.2.1",
-				"buffer": "^6.0.3",
-				"crypto-js": "^4.2.0",
+				"@noble/curves": "1.8.1",
+				"ansi-regex": "6.2.2",
+				"ansi-styles": "6.2.3",
+				"asn1js": "3.0.6",
+				"bignumber.js": "11.1.2",
+				"bn.js": "5.2.3",
+				"buffer": "6.0.3",
+				"crypto-js": "4.2.0",
+				"debug": "4.4.1",
 				"forge-light": "1.1.4",
-				"js-base64": "^3.7.7",
-				"react-native-get-random-values": "^1.11.0",
-				"spark-md5": "^3.0.2",
-				"tweetnacl": "^1.0.3",
-				"utf8": "^3.0.0"
+				"js-base64": "3.7.7",
+				"react-native-get-random-values": "2.0.0",
+				"spark-md5": "3.0.2",
+				"strip-ansi": "7.1.2",
+				"tweetnacl": "1.0.3",
+				"utf8": "3.0.0"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -1121,48 +475,281 @@
 				}
 			}
 		},
-		"node_modules/@hashgraph/proto": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.20.0.tgz",
-			"integrity": "sha512-XGIHRE9jr4wnnmCG8JeUD/nyeCiiYoUt35oRJz0QdCUwJYtbEsR6tPQxO90PxJJVDI5smT1c5i0f9wRRtFDhIA==",
-			"license": "Apache-2.0",
+		"node_modules/@hiero-ledger/cryptography/node_modules/@noble/curves": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+			"integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+			"license": "MIT",
 			"dependencies": {
-				"long": "^5.2.3",
-				"protobufjs": "7.2.5"
+				"@noble/hashes": "1.7.1"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
-		"node_modules/@hashgraph/sdk": {
-			"version": "2.69.0",
-			"resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.69.0.tgz",
-			"integrity": "sha512-jU7t7j0G9eFXsrQ183NkbvsuZGHiK+XvWRTJHKdfi/m9FE69Tu/r9hP2+BZk2lskRAiTXBb7haVo4iSnLPPzAQ==",
+		"node_modules/@hiero-ledger/cryptography/node_modules/@noble/hashes": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+			"integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.21.3 || >=16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@hiero-ledger/cryptography/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@hiero-ledger/cryptography/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@hiero-ledger/cryptography/node_modules/bignumber.js": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+			"integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+			"license": "MIT"
+		},
+		"node_modules/@hiero-ledger/cryptography/node_modules/react-native-get-random-values": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+			"integrity": "sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-base64-decode": "^1.0.0"
+			},
+			"peerDependencies": {
+				"react-native": ">=0.81"
+			}
+		},
+		"node_modules/@hiero-ledger/cryptography/node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk": {
+			"version": "2.85.0",
+			"resolved": "https://registry.npmjs.org/@hiero-ledger/sdk/-/sdk-2.85.0.tgz",
+			"integrity": "sha512-o9xmNHeIt7D2ZuetLTSJlrUI9S7dsEzaut61lOxIbne+9fDxGyYfkNrZaf65rOp2e/SltdwQMOseXyFXUdFqVg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ethersproject/abi": "^5.8.0",
-				"@ethersproject/bignumber": "^5.8.0",
-				"@ethersproject/bytes": "^5.8.0",
-				"@ethersproject/rlp": "^5.8.0",
-				"@grpc/grpc-js": "^1.12.6",
-				"@hashgraph/cryptography": "1.9.0",
-				"@hashgraph/proto": "2.20.0",
-				"bignumber.js": "^9.1.1",
-				"bn.js": "^5.1.1",
-				"crypto-js": "^4.2.0",
-				"js-base64": "^3.7.4",
-				"long": "^5.3.1",
-				"pino": "^9.6.0",
-				"pino-pretty": "^13.0.0",
-				"protobufjs": "7.2.5",
-				"rfc4648": "^1.5.3",
-				"utf8": "^3.0.0"
+				"@grpc/grpc-js": "1.12.6",
+				"@hiero-ledger/cryptography": "1.19.0",
+				"@hiero-ledger/proto": "2.31.0",
+				"ansi-regex": "6.2.2",
+				"ansi-styles": "6.2.3",
+				"bignumber.js": "11.1.2",
+				"bn.js": "5.2.3",
+				"crypto-js": "4.2.0",
+				"debug": "4.4.1",
+				"ethers": "6.16.0",
+				"js-base64": "3.7.4",
+				"long": "5.3.1",
+				"pino": "10.1.0",
+				"pino-pretty": "13.0.0",
+				"protobufjs": "8.2.0",
+				"rfc4648": "1.5.3",
+				"strip-ansi": "7.1.2",
+				"utf8": "3.0.0"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
-				"bn.js": "^5.2.1"
+				"bn.js": "5.2.3"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/@grpc/grpc-js": {
+			"version": "1.12.6",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
+			"integrity": "sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@grpc/proto-loader": "^0.7.13",
+				"@js-sdsl/ordered-map": "^4.4.2"
+			},
+			"engines": {
+				"node": ">=12.10.0"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/@hiero-ledger/proto": {
+			"version": "2.31.0",
+			"resolved": "https://registry.npmjs.org/@hiero-ledger/proto/-/proto-2.31.0.tgz",
+			"integrity": "sha512-6Uq9cSK1lqhMsP/Zwz3liKIzn5QtN2dvt/7EET00/LdubYxYqVxREs8SCtYbgOlzMy34n1Hl6eNeEDDFpkQhMg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"long": "5.3.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"ansi-regex": "6.2.2",
+				"ansi-styles": "6.2.3",
+				"debug": "4.4.1",
+				"protobufjs": "8.0.1",
+				"strip-ansi": "7.1.2"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/bignumber.js": {
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.2.tgz",
+			"integrity": "sha512-9idDyC15Vpk+53w4OfxEu2PqHSKFQUffrH1oTvnkJ9fduTJ032tpuI2sxS04oCzocklokWUZmWVEkTEQdLmUOQ==",
+			"license": "MIT"
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/js-base64": {
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.4.tgz",
+			"integrity": "sha512-wpM/wi20Tl+3ifTyi0RdDckS4YTD4Lf953mBRrpG8547T7hInHNPEj8+ck4gB8VDcGyeAWFK++Wb/fU1BeavKQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/long": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
+			"integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/pino": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-10.1.0.tgz",
+			"integrity": "sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==",
+			"license": "MIT",
+			"dependencies": {
+				"@pinojs/redact": "^0.4.0",
+				"atomic-sleep": "^1.0.0",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pino-std-serializers": "^7.0.0",
+				"process-warning": "^5.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^4.0.1",
+				"thread-stream": "^3.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/pino-pretty": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
+			"integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
+			"license": "MIT",
+			"dependencies": {
+				"colorette": "^2.0.7",
+				"dateformat": "^4.6.3",
+				"fast-copy": "^3.0.2",
+				"fast-safe-stringify": "^2.1.1",
+				"help-me": "^5.0.0",
+				"joycon": "^3.1.1",
+				"minimist": "^1.2.6",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^2.0.0",
+				"pump": "^3.0.0",
+				"secure-json-parse": "^2.4.0",
+				"sonic-boom": "^4.0.1",
+				"strip-json-comments": "^3.1.1"
+			},
+			"bin": {
+				"pino-pretty": "bin.js"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/protobufjs": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.2.0.tgz",
+			"integrity": "sha512-oI+GC9iPxrQEr6wragljFKH46/r3rNsm6eg7F2fp6kBUMnf6/mesDRdBuF4gK+OyaKJ8N4C1B9s9cCeYdqFikg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/rfc4648": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.3.tgz",
+			"integrity": "sha512-MjOWxM065+WswwnmNONOT+bD1nXzY9Km6u3kzvnx8F8/HXGZdz3T6e6vZJ8Q/RIMUSp/nxqjH3GwvJDy8ijeQQ==",
+			"license": "MIT"
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/secure-json-parse": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@hiero-ledger/sdk/node_modules/strip-ansi": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -1237,170 +824,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@istanbuljs/load-nyc-config": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"find-up": "^4.1.0",
-				"get-package-type": "^0.1.0",
-				"js-yaml": "^3.13.1",
-				"resolve-from": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"p-try": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/schema": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@jest/create-cache-key-function": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
-			"integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-			"integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/fake-timers": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-			"integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
-				"@types/node": "*",
-				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1409,33 +832,6 @@
 			"peer": true,
 			"dependencies": {
 				"@sinclair/typebox": "^0.27.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/transform": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-			"integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/core": "^7.11.6",
-				"@jest/types": "^29.6.3",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"babel-plugin-istanbul": "^6.1.1",
-				"chalk": "^4.0.0",
-				"convert-source-map": "^2.0.0",
-				"fast-json-stable-stringify": "^2.1.0",
-				"graceful-fs": "^4.2.9",
-				"jest-haste-map": "^29.7.0",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"pirates": "^4.0.4",
-				"slash": "^3.0.0",
-				"write-file-atomic": "^4.0.2"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1460,13 +856,24 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
@@ -1481,9 +888,9 @@
 			}
 		},
 		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
-			"integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1492,16 +899,16 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-			"integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.29",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1609,33 +1016,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@noble/curves": {
-			"version": "1.9.6",
-			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-			"integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
-			"license": "MIT",
-			"dependencies": {
-				"@noble/hashes": "1.8.0"
-			},
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
-		"node_modules/@noble/hashes": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-			"integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-			"license": "MIT",
-			"engines": {
-				"node": "^14.21.3 || >=16"
-			},
-			"funding": {
-				"url": "https://paulmillr.com/funding/"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1673,6 +1053,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@pinojs/redact": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+			"integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+			"license": "MIT"
 		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
@@ -1739,127 +1125,170 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@react-native/assets-registry": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.80.2.tgz",
-			"integrity": "sha512-+sI2zIM22amhkZqW+RpD3qDoopeRiezrTtZMP+Y3HI+6/2JbEq7DdyV/2YS1lrSSdyy3STW2V37Lt4dKqP0lEQ==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.86.0.tgz",
+			"integrity": "sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/@react-native/codegen": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.80.2.tgz",
-			"integrity": "sha512-eYad9ex9/RS6oFbbpu6LxsczktbhfJbJlTvtRlcWLJjJbFTeNr5Q7CgBT2/m5VtpxnJ/0YdmZ9vdazsJ2yp9kw==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
+			"integrity": "sha512-uTs9DBo3+/lUqinsGZK0FKJRBVClrwMXoZToaDxE1Q2SL2e55vs2GwyZfIKzPl5uJnbu4PfFMIp0/mLXLWUMuA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"glob": "^7.1.1",
-				"hermes-parser": "0.28.1",
+				"@babel/core": "^7.25.2",
+				"@babel/parser": "^7.29.0",
+				"hermes-parser": "0.36.0",
 				"invariant": "^2.2.4",
 				"nullthrows": "^1.1.1",
+				"tinyglobby": "^0.2.15",
 				"yargs": "^17.6.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "*"
 			}
 		},
 		"node_modules/@react-native/community-cli-plugin": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.2.tgz",
-			"integrity": "sha512-UBjsE+lv1YtThs56mgFaUdWv0jNE1oO58Lkbf3dn47F0e7YiTubIcvP6AnlaMhZF2Pmt9ky8J1jTpgItO9tGeg==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.86.0.tgz",
+			"integrity": "sha512-Jv8p1ebEPfTzs8gmrjsdT2XMXFfeAg45Pman+XPLFGaSeGAZkutRFRyX9Cs9aGTSOyIA9YPJ6vDNb1ayTf1FKQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@react-native/dev-middleware": "0.80.2",
-				"chalk": "^4.0.0",
+				"@react-native/dev-middleware": "0.86.0",
 				"debug": "^4.4.0",
 				"invariant": "^2.2.4",
-				"metro": "^0.82.2",
-				"metro-config": "^0.82.2",
-				"metro-core": "^0.82.2",
+				"metro": "^0.84.3",
+				"metro-config": "^0.84.3",
+				"metro-core": "^0.84.3",
 				"semver": "^7.1.3"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			},
 			"peerDependencies": {
-				"@react-native-community/cli": "*"
+				"@react-native-community/cli": "*",
+				"@react-native/metro-config": "0.86.0"
 			},
 			"peerDependenciesMeta": {
 				"@react-native-community/cli": {
+					"optional": true
+				},
+				"@react-native/metro-config": {
 					"optional": true
 				}
 			}
 		},
 		"node_modules/@react-native/debugger-frontend": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.80.2.tgz",
-			"integrity": "sha512-n3D88bqNk0bY+YjNxbM6giqva06xj+rgEfu91Pg+nJ0szSL2eLl7ULERJqI3hxFt0XGuTpTOxZgw/Po5maXa4g==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.86.0.tgz",
+			"integrity": "sha512-7Mb3nDfyJeys+ELF75Ageu7VKERlnIMoO+aNPoXqTXvz+b41L6l2CqMyLpDHxkBSlenij6gEepPNgaIyWHbJZw==",
 			"license": "BSD-3-Clause",
 			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+			}
+		},
+		"node_modules/@react-native/debugger-shell": {
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.86.0.tgz",
+			"integrity": "sha512-Y0zEkZzLz8ou6o/VLml1A31X/rMgc6DRjwxwzPMa94qRTMY070WeBCNTITQo4kKTBAUgbxh07oXPQqp0Tpja8w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.4.0",
+				"fb-dotslash": "0.5.8"
+			},
+			"engines": {
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/@react-native/dev-middleware": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.80.2.tgz",
-			"integrity": "sha512-8OeBEZNiApdbZaqTrrzeyFwXn/JwgJox7jdtjVAH56DggTVJXdbnyUjQ4ts6XAacEQgpFOAskoO730eyafOkAA==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.86.0.tgz",
+			"integrity": "sha512-20pTO6yTybmvXvro520H6C7jydIQnLKOl5qFtVEcHSdFrY63r3OGei+Rx9bILgSRmH6jgnfEcijcMx7pwWuQtw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@isaacs/ttlcache": "^1.4.1",
-				"@react-native/debugger-frontend": "0.80.2",
+				"@react-native/debugger-frontend": "0.86.0",
+				"@react-native/debugger-shell": "0.86.0",
 				"chrome-launcher": "^0.15.2",
-				"chromium-edge-launcher": "^0.2.0",
+				"chromium-edge-launcher": "^0.3.0",
 				"connect": "^3.6.5",
 				"debug": "^4.4.0",
 				"invariant": "^2.2.4",
 				"nullthrows": "^1.1.1",
 				"open": "^7.0.3",
 				"serve-static": "^1.16.2",
-				"ws": "^6.2.3"
+				"ws": "^7.5.10"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+			}
+		},
+		"node_modules/@react-native/dev-middleware/node_modules/ws": {
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8.3.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@react-native/gradle-plugin": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.80.2.tgz",
-			"integrity": "sha512-C5/FYbIfCXPFjF/hIcWFKC9rEadDDhPMbxE7tarGR9tmYKyb9o7fYvfNe8fFgbCRKelMHP0ShATz3T73pHHDfA==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.86.0.tgz",
+			"integrity": "sha512-a1RcfaEDqWExCGfCwadIxt4l8FvKYgFqeMf2uzeKyAOnb+vTGNIeCvifFL2MqvgaeYxlER437HbMIajGcuJ1pQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/@react-native/js-polyfills": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.80.2.tgz",
-			"integrity": "sha512-f63M3paxHK92p6L9o+AY7hV/YojCZAhb+fdDpSfOtDtCngWbBhd6foJrO6IybzDFERxlwErupUg3pqr5w3KJWw==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
+			"integrity": "sha512-zYy/Cjd1VTnZ2iCNaG9bDF9C3l2ntESiPRscjIlI5FKugu6aeTwsDSv1aI8Bc4Kp3vEdoVg+UQhLAhE4svREaQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/@react-native/normalize-colors": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.80.2.tgz",
-			"integrity": "sha512-08Ax7554Z31NXi5SQ6h1GsiSrlZEOYHQNSC7u+x91Tdiq87IXldW8Ib1N3ThXoDcD8bjr+I+MdlabEJw36/fFg==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
+			"integrity": "sha512-kG0wfCGghUKlfxkJyyHCDVutWVYWK7/DG58ojA/4v9EfulgF+osuSQmlbNb3rcKX58qutm7JcldSeVLgGFha9g==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/@react-native/virtualized-lists": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.80.2.tgz",
-			"integrity": "sha512-kXsIV2eB73QClbbH/z/lRhZkyj3Dke4tarM5w2yXSNwJthMPMfj4KqLZ6Lnf0nmPPjz7qo/voKtlrGqlM822Rg==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.86.0.tgz",
+			"integrity": "sha512-4/ZLXdf/OSpPDVO0AsQ1SJdRIzt5t9BNQ46QwGgxvX7/cirYR5k8KXctNGGgW8lQo2gZChEfY2zFCZg9nM/jiw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1867,12 +1296,12 @@
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			},
 			"peerDependencies": {
-				"@types/react": "^19.0.0",
+				"@types/react": "^19.2.0",
 				"react": "*",
-				"react-native": "*"
+				"react-native": "0.86.0"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -1954,86 +1383,11 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/@sinonjs/commons": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"type-detect": "4.0.8"
-			}
-		},
-		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-			"integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
-			}
-		},
-		"node_modules/@types/babel__core": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"node_modules/@types/babel__generator": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__template": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"node_modules/@types/babel__traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/types": "^7.28.2"
-			}
-		},
-		"node_modules/@types/graceful-fs": {
-			"version": "4.1.9",
-			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-			"integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
@@ -2085,17 +1439,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/stack-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.33",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
-			"integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2379,17 +1726,44 @@
 			}
 		},
 		"node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accepts/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/acorn": {
@@ -2413,6 +1787,12 @@
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
+		},
+		"node_modules/aes-js": {
+			"version": "4.0.0-beta.5",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+			"integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+			"license": "MIT"
 		},
 		"node_modules/agent-base": {
 			"version": "7.1.4",
@@ -2485,6 +1865,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
 			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
@@ -2594,13 +1975,6 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/async-limiter": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/async-settle": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/async-settle/-/async-settle-2.0.0.tgz",
@@ -2653,113 +2027,14 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/babel-jest": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-			"integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/transform": "^29.7.0",
-				"@types/babel__core": "^7.1.14",
-				"babel-plugin-istanbul": "^6.1.1",
-				"babel-preset-jest": "^29.6.3",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.8.0"
-			}
-		},
-		"node_modules/babel-plugin-istanbul": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-			"integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@istanbuljs/load-nyc-config": "^1.0.0",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-instrument": "^5.0.4",
-				"test-exclude": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/babel-plugin-jest-hoist": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-			"integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/template": "^7.3.3",
-				"@babel/types": "^7.3.3",
-				"@types/babel__core": "^7.1.14",
-				"@types/babel__traverse": "^7.0.6"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/babel-plugin-syntax-hermes-parser": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.28.1.tgz",
-			"integrity": "sha512-meT17DOuUElMNsL5LZN56d+KBp22hb0EfxWfuPUeoSi54e40v1W4C2V36P75FpsH9fVEfDKpw5Nnkahc8haSsQ==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz",
+			"integrity": "sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hermes-parser": "0.28.1"
-			}
-		},
-		"node_modules/babel-preset-current-node-syntax": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-bigint": "^7.8.3",
-				"@babel/plugin-syntax-class-properties": "^7.12.13",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5",
-				"@babel/plugin-syntax-import-attributes": "^7.24.7",
-				"@babel/plugin-syntax-import-meta": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-				"@babel/plugin-syntax-top-level-await": "^7.14.5"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0 || ^8.0.0-0"
-			}
-		},
-		"node_modules/babel-preset-jest": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-			"integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"babel-plugin-jest-hoist": "^29.6.3",
-				"babel-preset-current-node-syntax": "^1.0.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
+				"hermes-parser": "0.36.0"
 			}
 		},
 		"node_modules/bach": {
@@ -2781,6 +2056,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bare-events": {
@@ -2811,13 +2087,17 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/bignumber.js": {
-			"version": "9.3.1",
-			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-			"license": "MIT",
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.43",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+			"integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
 			"engines": {
-				"node": "*"
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/binary-extensions": {
@@ -2846,9 +2126,9 @@
 			}
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -2873,16 +2153,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/brorand": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-			"license": "MIT"
-		},
 		"node_modules/browserslist": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"version": "4.28.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+			"integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -2900,10 +2174,11 @@
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001726",
-				"electron-to-chromium": "^1.5.173",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.42",
+				"caniuse-lite": "^1.0.30001803",
+				"electron-to-chromium": "^1.5.389",
+				"node-releases": "^2.0.51",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3003,42 +2278,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/caller-callsite": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-			"integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"callsites": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/caller-callsite/node_modules/callsites": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-			"integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/caller-path": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-			"integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"caller-callsite": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3060,19 +2299,22 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001731",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
-			"integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
+			"version": "1.0.30001805",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+			"integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3181,9 +2423,9 @@
 			}
 		},
 		"node_modules/chromium-edge-launcher": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
-			"integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+			"integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -3191,25 +2433,15 @@
 				"escape-string-regexp": "^4.0.0",
 				"is-wsl": "^2.2.0",
 				"lighthouse-logger": "^1.0.0",
-				"mkdirp": "^1.0.4",
-				"rimraf": "^3.0.2"
+				"mkdirp": "^1.0.4"
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
+			"peer": true
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
@@ -3286,6 +2518,7 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/connect": {
@@ -3341,75 +2574,10 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/cosmiconfig": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"import-fresh": "^2.0.0",
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.13.1",
-				"parse-json": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/import-fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-			"integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"caller-path": "^2.0.0",
-				"resolve-from": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/resolve-from": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-			"integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -3638,32 +2806,11 @@
 			"peer": true
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.194",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz",
-			"integrity": "sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==",
+			"version": "1.5.389",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+			"integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
 			"license": "ISC",
 			"peer": true
-		},
-		"node_modules/elliptic": {
-			"version": "6.6.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-			"integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-			"license": "MIT",
-			"dependencies": {
-				"bn.js": "^4.11.9",
-				"brorand": "^1.1.0",
-				"hash.js": "^1.0.0",
-				"hmac-drbg": "^1.0.1",
-				"inherits": "^2.0.4",
-				"minimalistic-assert": "^1.0.1",
-				"minimalistic-crypto-utils": "^1.0.1"
-			}
-		},
-		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"license": "MIT"
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -3688,16 +2835,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
-			}
-		},
-		"node_modules/error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
 			}
 		},
 		"node_modules/error-stack-parser": {
@@ -4067,6 +3204,79 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/ethers": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+			"integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/ethers-io/"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@adraffy/ens-normalize": "1.10.1",
+				"@noble/curves": "1.2.0",
+				"@noble/hashes": "1.3.2",
+				"@types/node": "22.7.5",
+				"aes-js": "4.0.0-beta.5",
+				"tslib": "2.7.0",
+				"ws": "8.17.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/ethers/node_modules/@noble/curves": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+			"integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "1.3.2"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/ethers/node_modules/@noble/hashes": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+			"integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/ethers/node_modules/@types/node": {
+			"version": "22.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+			"integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.19.2"
+			}
+		},
+		"node_modules/ethers/node_modules/tslib": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+			"license": "0BSD"
+		},
+		"node_modules/ethers/node_modules/undici-types": {
+			"version": "6.19.8",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"license": "MIT"
+		},
 		"node_modules/event-target-shim": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -4091,9 +3301,9 @@
 			}
 		},
 		"node_modules/exponential-backoff": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-			"integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+			"integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
 			"license": "Apache-2.0",
 			"peer": true
 		},
@@ -4164,6 +3374,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-levenshtein": {
@@ -4172,15 +3383,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/fast-redact": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-			"integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/fast-safe-stringify": {
 			"version": "2.1.1",
@@ -4206,6 +3408,19 @@
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fb-dotslash": {
+			"version": "0.5.8",
+			"resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+			"integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+			"license": "(MIT OR Apache-2.0)",
+			"peer": true,
+			"bin": {
+				"dotslash": "bin/dotslash"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/fb-watchman": {
@@ -4480,12 +3695,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -4559,16 +3776,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-package-type": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/get-proto": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4588,6 +3795,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -4655,6 +3863,7 @@
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -4665,6 +3874,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -4958,16 +4168,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/hash.js": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-			"license": "MIT",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"minimalistic-assert": "^1.0.1"
-			}
-		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4986,32 +4186,28 @@
 			"integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
 			"license": "MIT"
 		},
+		"node_modules/hermes-compiler": {
+			"version": "250829098.0.14",
+			"resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.14.tgz",
+			"integrity": "sha512-5meXwsZxgiqFaJjNzwjzI9IyUkuGGBisu+z9BvQWmGVpjH6nz11hgqkyxe4dl8UAdyIV4lTbz91+Dlnjz0VxqA==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/hermes-estree": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-			"integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.36.0.tgz",
+			"integrity": "sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/hermes-parser": {
-			"version": "0.28.1",
-			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-			"integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+			"version": "0.36.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.36.0.tgz",
+			"integrity": "sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hermes-estree": "0.28.1"
-			}
-		},
-		"node_modules/hmac-drbg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-			"integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-			"license": "MIT",
-			"dependencies": {
-				"hash.js": "^1.0.3",
-				"minimalistic-assert": "^1.0.0",
-				"minimalistic-crypto-utils": "^1.0.1"
+				"hermes-estree": "0.36.0"
 			}
 		},
 		"node_modules/homedir-polyfill": {
@@ -5028,26 +4224,30 @@
 			}
 		},
 		"node_modules/http-errors": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-			"integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"depd": "2.0.0",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
-				"statuses": "2.0.1",
-				"toidentifier": "1.0.1"
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http-errors/node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5147,6 +4347,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -5180,6 +4381,7 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"once": "^1.3.0",
@@ -5283,13 +4485,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/is-bigint": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
@@ -5387,16 +4582,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-directory": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-			"integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-docker": {
@@ -5751,7 +4936,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -5764,137 +4948,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/istanbul-lib-coverage": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-instrument": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-			"integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@babel/parser": "^7.14.7",
-				"@istanbuljs/schema": "^0.1.2",
-				"istanbul-lib-coverage": "^3.2.0",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/istanbul-lib-instrument/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"license": "ISC",
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/jest-environment-node": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-			"integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/jest-get-type": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
 			"integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-haste-map": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-			"integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/graceful-fs": "^4.1.3",
-				"@types/node": "*",
-				"anymatch": "^3.0.3",
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.2.9",
-				"jest-regex-util": "^29.6.3",
-				"jest-util": "^29.7.0",
-				"jest-worker": "^29.7.0",
-				"micromatch": "^4.0.4",
-				"walker": "^1.0.8"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "^2.3.2"
-			}
-		},
-		"node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-			"integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-mock": {
-			"version": "29.7.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-			"integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-			"integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -5919,6 +4976,22 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-util/node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/jest-validate": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -5935,19 +5008,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-validate/node_modules/camelcase": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/jest-worker": {
@@ -6017,12 +5077,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/js-sha3": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-			"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-			"license": "MIT"
-		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6068,13 +5122,6 @@
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/json-parse-better-errors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
@@ -6380,46 +5427,45 @@
 			}
 		},
 		"node_modules/metro": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro/-/metro-0.82.5.tgz",
-			"integrity": "sha512-8oAXxL7do8QckID/WZEKaIFuQJFUTLzfVcC48ghkHhNK2RGuQq8Xvf4AVd+TUA0SZtX0q8TGNXZ/eba1ckeGCg==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+			"integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.24.7",
+				"@babel/code-frame": "^7.29.0",
 				"@babel/core": "^7.25.2",
-				"@babel/generator": "^7.25.0",
-				"@babel/parser": "^7.25.3",
-				"@babel/template": "^7.25.0",
-				"@babel/traverse": "^7.25.3",
-				"@babel/types": "^7.25.2",
-				"accepts": "^1.3.7",
-				"chalk": "^4.0.0",
+				"@babel/generator": "^7.29.1",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"accepts": "^2.0.0",
 				"ci-info": "^2.0.0",
 				"connect": "^3.6.5",
 				"debug": "^4.4.0",
 				"error-stack-parser": "^2.0.6",
 				"flow-enums-runtime": "^0.0.6",
 				"graceful-fs": "^4.2.4",
-				"hermes-parser": "0.29.1",
+				"hermes-parser": "0.35.0",
 				"image-size": "^1.0.2",
 				"invariant": "^2.2.4",
 				"jest-worker": "^29.7.0",
 				"jsc-safe-url": "^0.2.2",
 				"lodash.throttle": "^4.1.1",
-				"metro-babel-transformer": "0.82.5",
-				"metro-cache": "0.82.5",
-				"metro-cache-key": "0.82.5",
-				"metro-config": "0.82.5",
-				"metro-core": "0.82.5",
-				"metro-file-map": "0.82.5",
-				"metro-resolver": "0.82.5",
-				"metro-runtime": "0.82.5",
-				"metro-source-map": "0.82.5",
-				"metro-symbolicate": "0.82.5",
-				"metro-transform-plugins": "0.82.5",
-				"metro-transform-worker": "0.82.5",
-				"mime-types": "^2.1.27",
+				"metro-babel-transformer": "0.84.4",
+				"metro-cache": "0.84.4",
+				"metro-cache-key": "0.84.4",
+				"metro-config": "0.84.4",
+				"metro-core": "0.84.4",
+				"metro-file-map": "0.84.4",
+				"metro-resolver": "0.84.4",
+				"metro-runtime": "0.84.4",
+				"metro-source-map": "0.84.4",
+				"metro-symbolicate": "0.84.4",
+				"metro-transform-plugins": "0.84.4",
+				"metro-transform-worker": "0.84.4",
+				"mime-types": "^3.0.1",
 				"nullthrows": "^1.1.1",
 				"serialize-error": "^2.1.0",
 				"source-map": "^0.5.6",
@@ -6431,110 +5477,111 @@
 				"metro": "src/cli.js"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-babel-transformer": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.5.tgz",
-			"integrity": "sha512-W/scFDnwJXSccJYnOFdGiYr9srhbHPdxX9TvvACOFsIXdLilh3XuxQl/wXW6jEJfgIb0jTvoTlwwrqvuwymr6Q==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+			"integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
 				"flow-enums-runtime": "^0.0.6",
-				"hermes-parser": "0.29.1",
+				"hermes-parser": "0.35.0",
+				"metro-cache-key": "0.84.4",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
-			"integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
-			"integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hermes-estree": "0.29.1"
+				"hermes-estree": "0.35.0"
 			}
 		},
 		"node_modules/metro-cache": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.5.tgz",
-			"integrity": "sha512-AwHV9607xZpedu1NQcjUkua8v7HfOTKfftl6Vc9OGr/jbpiJX6Gpy8E/V9jo/U9UuVYX2PqSUcVNZmu+LTm71Q==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+			"integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"exponential-backoff": "^3.1.1",
 				"flow-enums-runtime": "^0.0.6",
 				"https-proxy-agent": "^7.0.5",
-				"metro-core": "0.82.5"
+				"metro-core": "0.84.4"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-cache-key": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.5.tgz",
-			"integrity": "sha512-qpVmPbDJuRLrT4kcGlUouyqLGssJnbTllVtvIgXfR7ZuzMKf0mGS+8WzcqzNK8+kCyakombQWR0uDd8qhWGJcA==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+			"integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-config": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.5.tgz",
-			"integrity": "sha512-/r83VqE55l0WsBf8IhNmc/3z71y2zIPe5kRSuqA5tY/SL/ULzlHUJEMd1szztd0G45JozLwjvrhAzhDPJ/Qo/g==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+			"integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"connect": "^3.6.5",
-				"cosmiconfig": "^5.0.5",
 				"flow-enums-runtime": "^0.0.6",
 				"jest-validate": "^29.7.0",
-				"metro": "0.82.5",
-				"metro-cache": "0.82.5",
-				"metro-core": "0.82.5",
-				"metro-runtime": "0.82.5"
+				"metro": "0.84.4",
+				"metro-cache": "0.84.4",
+				"metro-core": "0.84.4",
+				"metro-runtime": "0.84.4",
+				"yaml": "^2.6.1"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-core": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.5.tgz",
-			"integrity": "sha512-OJL18VbSw2RgtBm1f2P3J5kb892LCVJqMvslXxuxjAPex8OH7Eb8RBfgEo7VZSjgb/LOf4jhC4UFk5l5tAOHHA==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+			"integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"lodash.throttle": "^4.1.1",
-				"metro-resolver": "0.82.5"
+				"metro-resolver": "0.84.4"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-file-map": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.5.tgz",
-			"integrity": "sha512-vpMDxkGIB+MTN8Af5hvSAanc6zXQipsAUO+XUx3PCQieKUfLwdoa8qaZ1WAQYRpaU+CJ8vhBcxtzzo3d9IsCIQ==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+			"integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6549,13 +5596,13 @@
 				"walker": "^1.0.7"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-minify-terser": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.5.tgz",
-			"integrity": "sha512-v6Nx7A4We6PqPu/ta1oGTqJ4Usz0P7c+3XNeBxW9kp8zayS3lHUKR0sY0wsCHInxZlNAEICx791x+uXytFUuwg==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+			"integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6563,26 +5610,26 @@
 				"terser": "^5.15.0"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-resolver": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.5.tgz",
-			"integrity": "sha512-kFowLnWACt3bEsuVsaRNgwplT8U7kETnaFHaZePlARz4Fg8tZtmRDUmjaD68CGAwc0rwdwNCkWizLYpnyVcs2g==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+			"integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-runtime": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.5.tgz",
-			"integrity": "sha512-rQZDoCUf7k4Broyw3Ixxlq5ieIPiR1ULONdpcYpbJQ6yQ5GGEyYjtkztGD+OhHlw81LCR2SUAoPvtTus2WDK5g==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+			"integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6590,41 +5637,40 @@
 				"flow-enums-runtime": "^0.0.6"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-source-map": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.5.tgz",
-			"integrity": "sha512-wH+awTOQJVkbhn2SKyaw+0cd+RVSCZ3sHVgyqJFQXIee/yLs3dZqKjjeKKhhVeudgjXo7aE/vSu/zVfcQEcUfw==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+			"integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.25.3",
-				"@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
-				"@babel/types": "^7.25.2",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"flow-enums-runtime": "^0.0.6",
 				"invariant": "^2.2.4",
-				"metro-symbolicate": "0.82.5",
+				"metro-symbolicate": "0.84.4",
 				"nullthrows": "^1.1.1",
-				"ob1": "0.82.5",
+				"ob1": "0.84.4",
 				"source-map": "^0.5.6",
 				"vlq": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-symbolicate": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.5.tgz",
-			"integrity": "sha512-1u+07gzrvYDJ/oNXuOG1EXSvXZka/0JSW1q2EYBWerVKMOhvv9JzDGyzmuV7hHbF2Hg3T3S2uiM36sLz1qKsiw==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+			"integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6",
 				"invariant": "^2.2.4",
-				"metro-source-map": "0.82.5",
+				"metro-source-map": "0.84.4",
 				"nullthrows": "^1.1.1",
 				"source-map": "^0.5.6",
 				"vlq": "^1.0.0"
@@ -6633,80 +5679,100 @@
 				"metro-symbolicate": "src/index.js"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-transform-plugins": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.5.tgz",
-			"integrity": "sha512-57Bqf3rgq9nPqLrT2d9kf/2WVieTFqsQ6qWHpEng5naIUtc/Iiw9+0bfLLWSAw0GH40iJ4yMjFcFJDtNSYynMA==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+			"integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
-				"@babel/generator": "^7.25.0",
-				"@babel/template": "^7.25.0",
-				"@babel/traverse": "^7.25.3",
+				"@babel/generator": "^7.29.1",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
 				"flow-enums-runtime": "^0.0.6",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/metro-transform-worker": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.5.tgz",
-			"integrity": "sha512-mx0grhAX7xe+XUQH6qoHHlWedI8fhSpDGsfga7CpkO9Lk9W+aPitNtJWNGrW8PfjKEWbT9Uz9O50dkI8bJqigw==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+			"integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.25.2",
-				"@babel/generator": "^7.25.0",
-				"@babel/parser": "^7.25.3",
-				"@babel/types": "^7.25.2",
+				"@babel/generator": "^7.29.1",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"flow-enums-runtime": "^0.0.6",
-				"metro": "0.82.5",
-				"metro-babel-transformer": "0.82.5",
-				"metro-cache": "0.82.5",
-				"metro-cache-key": "0.82.5",
-				"metro-minify-terser": "0.82.5",
-				"metro-source-map": "0.82.5",
-				"metro-transform-plugins": "0.82.5",
+				"metro": "0.84.4",
+				"metro-babel-transformer": "0.84.4",
+				"metro-cache": "0.84.4",
+				"metro-cache-key": "0.84.4",
+				"metro-minify-terser": "0.84.4",
+				"metro-source-map": "0.84.4",
+				"metro-transform-plugins": "0.84.4",
 				"nullthrows": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
-		"node_modules/metro/node_modules/ci-info": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/metro/node_modules/hermes-estree": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
-			"integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+			"integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
 			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/metro/node_modules/hermes-parser": {
-			"version": "0.29.1",
-			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
-			"integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+			"version": "0.35.0",
+			"resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+			"integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"hermes-estree": "0.29.1"
+				"hermes-estree": "0.35.0"
+			}
+		},
+		"node_modules/metro/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/metro/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/metro/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -6773,18 +5839,6 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/minimalistic-assert": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"license": "ISC"
-		},
-		"node_modules/minimalistic-crypto-utils": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "9.0.5",
@@ -6895,9 +5949,9 @@
 			"license": "MIT"
 		},
 		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -6923,16 +5977,20 @@
 			"peer": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"license": "MIT",
-			"peer": true
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -6959,16 +6017,16 @@
 			"peer": true
 		},
 		"node_modules/ob1": {
-			"version": "0.82.5",
-			"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.5.tgz",
-			"integrity": "sha512-QyQQ6e66f+Ut/qUVjEce0E/wux5nAGLXYZDn1jr15JWstHsCH3l6VVrg8NKDptW9NEiBXKOJeGF/ydxeSDF3IQ==",
+			"version": "0.84.4",
+			"resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+			"integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"flow-enums-runtime": "^0.0.6"
 			},
 			"engines": {
-				"node": ">=18.18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -7239,16 +6297,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7275,20 +6323,6 @@
 			},
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/parse-passwd": {
@@ -7326,6 +6360,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -7335,6 +6370,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7344,7 +6380,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -7408,28 +6443,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pino": {
-			"version": "9.7.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
-			"integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
-			"license": "MIT",
-			"dependencies": {
-				"atomic-sleep": "^1.0.0",
-				"fast-redact": "^3.1.1",
-				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^2.0.0",
-				"pino-std-serializers": "^7.0.0",
-				"process-warning": "^5.0.0",
-				"quick-format-unescaped": "^4.0.3",
-				"real-require": "^0.2.0",
-				"safe-stable-stringify": "^2.3.1",
-				"sonic-boom": "^4.0.1",
-				"thread-stream": "^3.0.0"
-			},
-			"bin": {
-				"pino": "bin.js"
-			}
-		},
 		"node_modules/pino-abstract-transport": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
@@ -7439,57 +6452,11 @@
 				"split2": "^4.0.0"
 			}
 		},
-		"node_modules/pino-pretty": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.1.tgz",
-			"integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
-			"license": "MIT",
-			"dependencies": {
-				"colorette": "^2.0.7",
-				"dateformat": "^4.6.3",
-				"fast-copy": "^3.0.2",
-				"fast-safe-stringify": "^2.1.1",
-				"help-me": "^5.0.0",
-				"joycon": "^3.1.1",
-				"minimist": "^1.2.6",
-				"on-exit-leak-free": "^2.1.0",
-				"pino-abstract-transport": "^2.0.0",
-				"pump": "^3.0.0",
-				"secure-json-parse": "^4.0.0",
-				"sonic-boom": "^4.0.1",
-				"strip-json-comments": "^5.0.2"
-			},
-			"bin": {
-				"pino-pretty": "bin.js"
-			}
-		},
-		"node_modules/pino-pretty/node_modules/strip-json-comments": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.2.tgz",
-			"integrity": "sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/pino-std-serializers": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
 			"integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
 			"license": "MIT"
-		},
-		"node_modules/pirates": {
-			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/pluralize": {
 			"version": "8.0.0",
@@ -7708,9 +6675,9 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "19.1.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-			"integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+			"integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -7758,74 +6725,85 @@
 			"peer": true
 		},
 		"node_modules/react-native": {
-			"version": "0.80.2",
-			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.80.2.tgz",
-			"integrity": "sha512-6ySV4qTJo/To3lgpG/9Mcg/ZtvExqOVZuT7JVGcO5rS2Bjvl/yUAkQF0hTnbRb2Ch6T5MlKghrM4OeHX+KA9Pg==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.86.0.tgz",
+			"integrity": "sha512-17ALh/dd6AO4pgOVmOO5Axll5PbErEo3XFyLokyzW6usyi+OShIEPwUW26wLPlhVifgSOIfECCH0WN+0IqtJ1w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@jest/create-cache-key-function": "^29.7.0",
-				"@react-native/assets-registry": "0.80.2",
-				"@react-native/codegen": "0.80.2",
-				"@react-native/community-cli-plugin": "0.80.2",
-				"@react-native/gradle-plugin": "0.80.2",
-				"@react-native/js-polyfills": "0.80.2",
-				"@react-native/normalize-colors": "0.80.2",
-				"@react-native/virtualized-lists": "0.80.2",
+				"@react-native/assets-registry": "0.86.0",
+				"@react-native/codegen": "0.86.0",
+				"@react-native/community-cli-plugin": "0.86.0",
+				"@react-native/gradle-plugin": "0.86.0",
+				"@react-native/js-polyfills": "0.86.0",
+				"@react-native/normalize-colors": "0.86.0",
+				"@react-native/virtualized-lists": "0.86.0",
 				"abort-controller": "^3.0.0",
 				"anser": "^1.4.9",
 				"ansi-regex": "^5.0.0",
-				"babel-jest": "^29.7.0",
-				"babel-plugin-syntax-hermes-parser": "0.28.1",
+				"babel-plugin-syntax-hermes-parser": "0.36.0",
 				"base64-js": "^1.5.1",
-				"chalk": "^4.0.0",
 				"commander": "^12.0.0",
 				"flow-enums-runtime": "^0.0.6",
-				"glob": "^7.1.1",
+				"hermes-compiler": "250829098.0.14",
 				"invariant": "^2.2.4",
-				"jest-environment-node": "^29.7.0",
 				"memoize-one": "^5.0.0",
-				"metro-runtime": "^0.82.2",
-				"metro-source-map": "^0.82.2",
+				"metro-runtime": "^0.84.3",
+				"metro-source-map": "^0.84.3",
 				"nullthrows": "^1.1.1",
 				"pretty-format": "^29.7.0",
 				"promise": "^8.3.0",
-				"react-devtools-core": "^6.1.1",
+				"react-devtools-core": "^6.1.5",
 				"react-refresh": "^0.14.0",
 				"regenerator-runtime": "^0.13.2",
-				"scheduler": "0.26.0",
+				"scheduler": "0.27.0",
 				"semver": "^7.1.3",
 				"stacktrace-parser": "^0.1.10",
+				"tinyglobby": "^0.2.15",
 				"whatwg-fetch": "^3.0.0",
-				"ws": "^6.2.3",
+				"ws": "^7.5.10",
 				"yargs": "^17.6.2"
 			},
 			"bin": {
 				"react-native": "cli.js"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
 			},
 			"peerDependencies": {
-				"@types/react": "^19.1.0",
-				"react": "^19.1.0"
+				"@react-native/jest-preset": "0.86.0",
+				"@types/react": "^19.1.1",
+				"react": "^19.2.3"
 			},
 			"peerDependenciesMeta": {
+				"@react-native/jest-preset": {
+					"optional": true
+				},
 				"@types/react": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/react-native-get-random-values": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
-			"integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
+		"node_modules/react-native/node_modules/ws": {
+			"version": "7.5.11",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
 			"license": "MIT",
-			"dependencies": {
-				"fast-base64-decode": "^1.0.0"
+			"peer": true,
+			"engines": {
+				"node": ">=8.3.0"
 			},
 			"peerDependencies": {
-				"react-native": ">=0.56"
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": "^5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-refresh": {
@@ -8057,17 +7035,12 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/rfc4648": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
-			"integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
-			"license": "MIT"
-		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -8166,27 +7139,11 @@
 			"peer": true
 		},
 		"node_modules/scheduler": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/secure-json-parse": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
-			"integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/semver": {
 			"version": "7.7.2",
@@ -8214,25 +7171,25 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-			"integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"debug": "2.6.9",
 				"depd": "2.0.0",
 				"destroy": "1.2.0",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "2.0.0",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
 				"mime": "1.6.0",
 				"ms": "2.1.3",
-				"on-finished": "2.4.1",
+				"on-finished": "~2.4.1",
 				"range-parser": "~1.2.1",
-				"statuses": "2.0.1"
+				"statuses": "~2.0.2"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -8255,6 +7212,16 @@
 			"license": "MIT",
 			"peer": true
 		},
+		"node_modules/send/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/send/node_modules/on-finished": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8269,9 +7236,9 @@
 			}
 		},
 		"node_modules/send/node_modules/statuses": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-			"integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -8301,16 +7268,16 @@
 			}
 		},
 		"node_modules/serve-static": {
-			"version": "1.16.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.19.0"
+				"send": "~0.19.1"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -8371,7 +7338,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -8384,7 +7350,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8479,17 +7444,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/signal-exit": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"license": "ISC",
-			"peer": true
-		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8558,36 +7517,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 10.x"
-			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-			"license": "BSD-3-Clause",
-			"peer": true
-		},
-		"node_modules/stack-utils": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"escape-string-regexp": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/stack-utils/node_modules/escape-string-regexp": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/stackframe": {
@@ -8715,7 +7644,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8781,14 +7709,14 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.43.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+			"integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
 			"license": "BSD-2-Clause",
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.14.0",
+				"acorn": "^8.15.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
 			},
@@ -8805,45 +7733,6 @@
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/test-exclude": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"@istanbuljs/schema": "^0.1.2",
-				"glob": "^7.1.4",
-				"minimatch": "^3.0.4"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/test-exclude/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
 		},
 		"node_modules/text-decoder": {
 			"version": "1.2.3",
@@ -8877,6 +7766,54 @@
 			"integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
 		},
 		"node_modules/title-case": {
 			"version": "3.0.3",
@@ -8984,16 +7921,6 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -9084,9 +8011,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -9300,7 +8227,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -9406,28 +8332,25 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"license": "ISC"
 		},
-		"node_modules/write-file-atomic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-			"integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.7"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
 		"node_modules/ws": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-			"integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
 			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"async-limiter": "~1.0.0"
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/xml2js": {
@@ -9469,6 +8392,22 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"license": "ISC",
 			"peer": true
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yaml-ast-parser": {
 			"version": "0.0.43",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"n8n-workflow": "*"
 	},
 	"dependencies": {
-		"@hashgraph/sdk": "^2.64.5",
+		"@hiero-ledger/sdk": "^2.85.0",
 		"openapi-fetch": "^0.14.0"
 	}
 }


### PR DESCRIPTION
## What

Replaces the deprecated `@hashgraph/sdk` with `@hiero-ledger/sdk`. The Hedera JS SDK was donated to the Linux Foundation and rebranded "Hiero" — the package moved namespaces but the exported class API is unchanged.

## Changes

- **Dependency:** `@hashgraph/sdk@^2.64.5` → `@hiero-ledger/sdk@^2.85.0`
- **Imports:** updated the import specifier across 24 `.ts` files (`Client`, `PrivateKey`, `TransferTransaction`, `TokenCreateTransaction`, etc.)
- Regenerated `package-lock.json` (0 `@hashgraph` references remain)

## Verification

- `npm run build` (`tsc` + icon bundle) passes with no errors — every imported symbol resolves against the new package, confirming the API surface is identical.
- Smoke-tested end-to-end against **testnet** in a local n8n instance across distinct SDK transaction families:
  - Transfer HBAR (`TransferTransaction`, `Hbar`)
  - Create + Mint Fungible Token (`TokenCreateTransaction`, `TokenMintTransaction`)
  - Create NFT + Mint NFT (byte-array metadata path)
  - Create Topic + Submit Message (`TopicCreateTransaction`, `TopicMessageSubmitTransaction`)
  - Account Balance + Token Balance (mirror-node REST paths)

All operations returned `SUCCESS`.

## Note

This also bumps the SDK ~21 minor versions (`2.64` → `2.85`). No behavior changes were observed in the tested paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)